### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/js/questionnaire.js
+++ b/src/js/questionnaire.js
@@ -2,11 +2,11 @@
 $("[data-must-answer=true] input[data-type=text], [data-must-answer=true] textarea").on("input", function (e) {
     var $this = $(this);
     if ($this.val() == "" && $this.html() == "") {
-        $this.parents(".question").find(".dTip").html(questionnaireI18n.must_input);
+        $this.parents(".question").find(".dTip").text(questionnaireI18n.must_input);
         quesAnswerList[$this.parents(".question").attr("data-qid")] = false;
     }
     else {
-        $this.parents(".question").find(".dTip").html("");
+        $this.parents(".question").find(".dTip").text("");
         quesAnswerList[$this.parents(".question").attr("data-qid")] = true;
     }
 })
@@ -14,19 +14,19 @@ $("[data-must-answer=true] input[data-type=text], [data-must-answer=true] textar
 $("[data-must-answer=true] .input input").on("change", function (e) {
     var $this = $(this);
     if ($this.parents(".questionAnswers").find("input:checked").length == 0) {
-        $this.parents(".question").find(".dTip").html(questionnaireI18n.must_input);
+        $this.parents(".question").find(".dTip").text(questionnaireI18n.must_input);
         quesAnswerList[$this.parents(".question").attr("data-qid")] = false;
     }
     else if ($this.parents(".question").attr("data-num-limit") && $this.parents(".questionAnswers").find("input:checked").length < Number($this.parents(".question").attr("data-num-limit").split(",")[0])) {
-        $this.parents(".question").find(".dTip").html(questionnaireI18n.select_min_limit.replace(/{n}/g, $this.parents(".question").attr("data-num-limit").split(",")[0]));
+        $this.parents(".question").find(".dTip").text(questionnaireI18n.select_min_limit.replace(/{n}/g, $this.parents(".question").attr("data-num-limit").split(",")[0]));
         quesAnswerList[$this.parents(".question").attr("data-qid")] = false;
     }
     else if ($this.parents(".question").attr("data-num-limit") && $this.parents(".questionAnswers").find("input:checked").length > Number($this.parents(".question").attr("data-num-limit").split(",")[1])) {
-        $this.parents(".question").find(".dTip").html(questionnaireI18n.select_max_limit.replace(/{n}/g, $this.parents(".question").attr("data-num-limit").split(",")[1]));
+        $this.parents(".question").find(".dTip").text(questionnaireI18n.select_max_limit.replace(/{n}/g, $this.parents(".question").attr("data-num-limit").split(",")[1]));
         quesAnswerList[$this.parents(".question").attr("data-qid")] = false;
     }
     else {
-        $this.parents(".question").find(".dTip").html("");
+        $this.parents(".question").find(".dTip").text("");
         quesAnswerList[$this.parents(".question").attr("data-qid")] = true;
     }
 })
@@ -54,7 +54,7 @@ function submitQue() {
     });
     if (quesAnswerList.indexOf(false) != -1) {
         window.location.href = "#q_" + quesAnswerList.indexOf(false);
-        $(`#q_${quesAnswerList.indexOf(false)}`).find(".dTip:empty").html(questionnaireI18n.must_input);
+        $(`#q_${quesAnswerList.indexOf(false)}`).find(".dTip:empty").text(questionnaireI18n.must_input);
         $(`#q_${quesAnswerList.indexOf(false)}`).attr("data-mention", "true");
         setTimeout(() => {
             $(`#q_${quesAnswerList.indexOf(false)}`).attr("data-mention", "false");


### PR DESCRIPTION
Potential fix for [https://github.com/nm-Team/WebSite/security/code-scanning/3](https://github.com/nm-Team/WebSite/security/code-scanning/3)

Use **text insertion instead of HTML insertion** for user/DOM-influenced strings.

Best fix in this snippet:
- Replace `.html(...)` with `.text(...)` for all `.dTip` message writes that are plain text.
- Keep empty-clear behavior by using `.text("")` instead of `.html("")`.

Specifically in `src/js/questionnaire.js`, update the `.dTip` writes at:
- lines 5, 9, 17, 21, 25, 29, and 57.

No new imports or helper methods are needed. This preserves functionality (showing validation messages) while preventing HTML interpretation/XSS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
